### PR TITLE
Redirect admins to respond-to-request form on creating a new FOI request

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -264,7 +264,7 @@ class RequestsController < ApplicationController
       if saved_ok
         format.html do
             if self.is_admin_view?
-                redirect_to requests_path(:is_admin=>"admin"), :notice => 'Request was successfully created.'
+                redirect_to request_path(@request), :notice => 'Request was successfully created.'
             else
                 redirect_to requests_path, :notice => "Your request has been received. A response will be sent to <#{@request.requestor.email}>."
             end


### PR DESCRIPTION
Simplifies the process of changing the status after an FOI request has been created.

Closes #210 
(replacement PR as I broke the original one)