### PR TITLE
Don't verify the TLS certificate of the Alaveteli install.

### DIFF
--- a/lib/tasks/foi.rake
+++ b/lib/tasks/foi.rake
@@ -30,7 +30,7 @@ namespace :foi do
             http.use_ssl = true
 
             http.ca_path = MySociety::Config.get("SSL_CA_PATH", "/etc/ssl/certs/")
-            http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+            http.verify_mode = OpenSSL::SSL::VERIFY_NONE
             request = Net::HTTP::Get.new(uri.request_uri)
             response = http.request(request)
             events = ActiveSupport::JSON.decode(response.body)


### PR DESCRIPTION
Ruby 1.8.7 doesn't support Server Name Indication (SNI) for SSL/TLS.
As we're now running WhatDoTheyKnow and another site securely from the
same server, VERIFY_PEER was causing the foi task to error.

Fixes https://github.com/mysociety/foi-register/issues/227