### PR TITLE
Issues/231 fix assessing bug

### DIFF
--- a/app/assets/javascripts/requests.js.coffee.erb
+++ b/app/assets/javascripts/requests.js.coffee.erb
@@ -76,13 +76,13 @@ $ ->
   $('#request_due_date').datepicker({"dateFormat": "dd/mm/yy"})
 
   # In-place state editing for request state
-  $('#admin-request-list .admin-request-state').dblclick () ->
+  $('#admin-request-list .admin-request-state-editable').dblclick () ->
     $this = $ this
     $this.find(".label").hide()
     $this.find(".state-editor").show()
   .mouseup () ->
     return false
-  $('#admin-request-list .admin-request-state .state-editor select').change () ->
+  $('#admin-request-list .admin-request-state-editable .state-editor select').change () ->
     $this = $ this
     $td = $this.closest "td"
     request_id = $this.closest("tr").attr("id").substring("request-".length)

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -289,6 +289,14 @@ class RequestsController < ApplicationController
     state_tag = params[:state]
     state = Request::STATES[state_tag]
 
+    # quit early if the state's invalid
+    unless state
+      render :json => {
+        "ok" => false
+      }
+      return
+    end
+
     request.state = state_tag
     if request.save!
       render :json => {

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -66,6 +66,12 @@ class RequestsController < ApplicationController
   # GET /requests/1.json
   def show
     @request = Request.find(params[:id])
+
+    @request_states = Request::STATES
+    unless @request.state == "new"
+      @request_states.delete_if { |state| state == "new"}
+    end
+
     raise ActiveRecord::RecordNotFound if !is_admin_view? && !@request.is_published
 
     respond_to do |format|

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -7,12 +7,14 @@ class ResponsesController < ApplicationController
   def edit
     @response = Response.find(params[:id])
     @request = @response.request
+    @request_states = Request::STATES
   end
 
   # POST /request/:request_id/responses
   # POST /request/:request_id/responses.json
   def create
     @request = Request.find(params[:request_id])
+    @request_states = Request::STATES
 
     response = params[:response]
     request_attributes = response.delete(:request_attributes)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -97,11 +97,11 @@ class Request < ActiveRecord::Base
     ]})
 
   def state_title
-    STATES[state][0]
+    STATES[state][0] if STATES[state]
   end
 
   def state_description
-    STATES[state][1]
+    STATES[state][1] if STATES[state]
   end
 
   def state=(value)

--- a/app/views/requests/admin_index.html.erb
+++ b/app/views/requests/admin_index.html.erb
@@ -43,14 +43,16 @@
         <td><%= request.date_received_or_created.to_s(:short) %></td>
         <td><%= request.requestor %></td>
         <td><%= link_to request.title, request_path(request) %></td>
-        <td class="admin-request-state">
+        <td class="admin-request-state<%= ['new', 'assessing'].include?(request.state) ? "-editable": nil%>">
           <span rel="tooltip" title="<%= request.state_description %>" class="state label"><%= request.state_title %></span>
-          <span class="state-editor" style="display:none">
-            <%= form_for(request) do |f|
-              f.select(:state, Request::STATES.collect do |tag, (name, description)|
-                [name, tag, {:title => description}]
-              end)
-            end %>
+          <% if ['new', 'assessing'].include?(request.state) %>
+              <span class="state-editor" style="display:none">
+                <%= form_for(request) do |f|
+                  f.select(:state, Request::STATES.select {|state| ["new", "assessing"].include?(state) }.collect do |tag, (name, description)|
+                    [name, tag, {:title => description}]
+                  end)
+                end %>
+            <% end %>
           </span>
         </td>
         <td>

--- a/app/views/responses/_reply_fields.html.erb
+++ b/app/views/responses/_reply_fields.html.erb
@@ -44,7 +44,7 @@
   <%= response.fields_for(:request, @request) do |s| %>
     <div class="field">
       <%= s.label :state %>
-      <%= s.select(:state, Request::STATES.collect do |tag, (name, description)|
+      <%= s.select(:state, @request_states.collect do |tag, (name, description)|
         [name, tag, {:title => description}]
       end) %>
     </div>

--- a/test/functional/responses_controller_test.rb
+++ b/test/functional/responses_controller_test.rb
@@ -28,6 +28,35 @@ class ResponsesControllerTest < ActionController::TestCase
     assert response.body =~ /State can&#x27;t be New/
   end
 
+  test "should not create a response when the request state is changed " \
+       "to assessing and the public_part is empty" do
+    request = Request.find(requests(:overdue).id)
+    response_attributes = @response_1.attributes
+    response_attributes[:request_attributes] = {:state => "assessing"}
+    response_attributes[:public_part] = ""
+
+    assert_no_difference('Response.count') do
+      post :create, :response => response_attributes, :request_id => request.id
+    end
+
+    request = Request.find(requests(:overdue).id)
+    assert_equal(request.state, "assessing")
+  end
+
+  test "should create a response when the request state is changed " \
+       "to assessing and the public_part is NOT empty" do
+    request = Request.find(requests(:overdue).id)
+    response_attributes = {:request_attributes => {:state => "assessing"}}
+
+    assert_no_difference('Response.count') do
+      post :create, :response => response_attributes, :request_id => request.id
+    end
+
+    request = Request.find(requests(:overdue).id)
+    assert_equal(request.state, "assessing")
+    assert_redirected_to root_path
+  end
+
   test "should set the request state when creating a response" do
     response_attributes = @response_1.attributes
     response_attributes[:request_attributes] = {:state => "disclosed"}


### PR DESCRIPTION
Closes #231 

Allows admin users to mark new requests as 'Assessing' without making a response to the requestor (admins may still make a response at this stage if they wish by filling in the Public Part box as before).

Fixes a bug in the dropdown menu - accessed by a double click on the admin requests screen that allowed completed requests to be flagged as New or Assessing with no checks in place - it now only allows fast switching between New and Assessing statuses.