### PR TITLE
Set flash message to confirm state change

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -23,7 +23,10 @@ class ResponsesController < ApplicationController
     if @request.state != "assessing" and request_attributes[:state] == "assessing" and response[:public_part].blank?
       @request.state = "assessing"
       @request.save
-      redirect_to :root
+      respond_to do |format|
+        format.html { redirect_to requests_path(:is_admin => "admin"),
+                                  :notice => "Request #{@request.administrative_id} flagged as Assessing (no response sent)" }
+      end
       return
     end
 

--- a/test/functional/responses_controller_test.rb
+++ b/test/functional/responses_controller_test.rb
@@ -41,20 +41,22 @@ class ResponsesControllerTest < ActionController::TestCase
 
     request = Request.find(requests(:overdue).id)
     assert_equal(request.state, "assessing")
+    assert_redirected_to requests_path(:is_admin => 'admin')
   end
 
   test "should create a response when the request state is changed " \
        "to assessing and the public_part is NOT empty" do
     request = Request.find(requests(:overdue).id)
-    response_attributes = {:request_attributes => {:state => "assessing"}}
+    response_attributes = @response_1.attributes
+    response_attributes[:request_attributes] = {:state => "assessing"}
 
-    assert_no_difference('Response.count') do
+    assert_difference('Response.count') do
       post :create, :response => response_attributes, :request_id => request.id
     end
 
     request = Request.find(requests(:overdue).id)
     assert_equal(request.state, "assessing")
-    assert_redirected_to root_path
+    assert_redirected_to request_path(request, :is_admin => "admin")
   end
 
   test "should set the request state when creating a response" do


### PR DESCRIPTION
Fixes #233 

When using the Respond action to change state from New -> Assessing, confirm that the change has worked (and that no response has gone to the requestor) following the redirect back to the list of requests