### PR TITLE
Fix bug with syncing requests with empty user_urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
 
   gem 'debugger', :require => 'ruby-debug', :platforms => :mri_19, :git => "https://github.com/cldwalker/debugger"
   gem 'ruby-debug', :platforms => :mri_18
+  gem 'webmock'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     activesupport (3.2.21)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    addressable (2.3.7)
     annotate (2.5.0)
       rake
     arel (3.0.3)
@@ -81,6 +82,8 @@ GEM
     coffee-script-source (1.3.3)
     columnize (0.3.6)
     commonjs (0.2.6)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     daemons (1.0.10)
     debugger-linecache (1.1.2)
       debugger-ruby_core_source (>= 1.1.1)
@@ -176,6 +179,7 @@ GEM
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
     ruby-rc4 (0.1.5)
+    safe_yaml (1.0.4)
     sass (3.1.20)
     sass-rails (3.2.5)
       railties (~> 3.2.0)
@@ -212,6 +216,9 @@ GEM
     uglifier (1.2.6)
       execjs (>= 0.3.0)
       multi_json (~> 1.3)
+    webmock (1.20.4)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     will_paginate (3.0.5)
     xapian-full-alaveteli (1.2.9.5)
 
@@ -248,6 +255,7 @@ DEPENDENCIES
   strip_attributes
   therubyracer
   uglifier (>= 1.0.3)
+  webmock
   will_paginate (~> 3.0.5)
   xapian-full-alaveteli (~> 1.2.9.4)
   yaml_db!

--- a/app/models/requestor.rb
+++ b/app/models/requestor.rb
@@ -34,4 +34,23 @@ class Requestor < ActiveRecord::Base
       name
     end
   end
+
+  class << self
+    def find_by_external_url_scheme_insensitive(url)
+      # Find a Requestor by their url, but in a URL scheme-insensitive way.
+      instance = self.find_by_external_url(url)
+      # check to see if there's an http or https equivalent
+      # of the url before creating a new requestor
+      if instance.nil?
+        case url[0..4]
+        when "http:"
+          instance = self.find_by_external_url("https://#{url[7..-1]}")
+        when "https"
+          instance = self.find_by_external_url("http://#{url[8..-1]}")
+        end
+      end
+      instance
+    end
+  end
+
 end

--- a/app/views/request_mailer/acknowledgement.text.erb
+++ b/app/views/request_mailer/acknowledgement.text.erb
@@ -10,6 +10,6 @@ Details of your request:
 
 Your request can be viewed online at: <%= Rails.application.routes.url_helpers.request_url(nil, @request, :host => MySociety::Config.get("DOMAIN", "localhost:3000"), :protocol => (MySociety::Config.get("FOI_REG_SECURE", false) ? 'https' : 'http')) %>
 
-Wendy Kassamani
+
 Information Compliance Officer
 Tel: 01273 296636

--- a/app/views/response_mailer/email_response.html.erb
+++ b/app/views/response_mailer/email_response.html.erb
@@ -18,15 +18,15 @@
 
 <p>Should you have any further queries about this request, please contact me via the details at the foot of this email, quoting the reference number given above.</p>
 
-<p>If you are not satisfied with the handling of your request, you can appeal. Write to:</p>
+<p>If you are not satisfied with the handling of your request, you can appeal (Internal Review) within 2 months of the completed FOI. Write to:</p>
 
 <p>Freedom of Information Appeals<br>
 Brighton & Hove City Council<br>
-ICT Room lst Floor<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove BN3 4AH<br>
-jan.mccartney@brighton-hove.gcsx.gov.uk</p>
+ICT 4th Floor<br>
+Kings House<br>
+Grand Avenue<br>
+Hove BN3 3LS<br>
+information.governance@brighton-hove.gov.uk</p>
 
 <p>If you are still not satisfied after your complaint has been investigated, you can escalate your complaint to the Information Commissioners Office. The contact details are:</p>
 
@@ -35,24 +35,23 @@ Wycliffe House<br>
 Water Lane<br>
 Wilmslow<br>
 Cheshire SK9 5AF<br>
-Telephone number: 01625 545745<br>
-e-mail: <a href="mailto:data@dataprotection.gov.uk">data@dataprotection.gov.uk</a><br>
-Website: <a href="www.dataprotection.gov.uk">www.dataprotection.gov.uk</a></p>
+Helpline: 0303 123 1113 (local rate) or 01625 545 745 (national rate)<br>
+e-mail: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
+Website: <a href="www.ICO.org.uk">www.ICO.org.uk</a></p>
 
 
 <p>We can also answer queries regarding this process: please contact me via the contact details below.</p>
 
-<p><b>Wendy Kassamani</b><br>
-Information Compliance Officer<br>
+<p><b>Information Compliance Officer</b><br>
 Brighton & Hove City Council<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove, BN3 4AH<br>
-<a href="mailto:Wendy.Kassamani@Brighton-Hove.gov.uk">Wendy.Kassamani@Brighton-Hove.gov.uk</a></p>
+Kings House<br>
+Grand Avenue<br>
+Hove, BN3 3LS<br>
+<a href="mailto:freedomofinformation@Brighton-Hove.gov.uk">freedomofinformation@Brighton-Hove.gov.uk</a></p>
 
 
 <p><b>Re-use of Public Sector Information and Copyright Statement</b></p>
 <p>Where information has been supplied, you are advised that the copyright in that material is owned by Brighton &amp; Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.</p>
 
-<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.</p>
+<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.</p>

--- a/app/views/response_mailer/email_response.text.erb
+++ b/app/views/response_mailer/email_response.text.erb
@@ -22,10 +22,8 @@ If you are not satisfied with the handling of your request, you can appeal. Writ
 
 Freedom of Information Appeals
 Brighton & Hove City Council
-ICT Room lst Floor
-Hove Town Hall
-Norton Road
-Hove BN3 4AH
+ICT 4th Floor Kings House Grand Avenue
+Hove BN3 3LS
 jan.mccartney@brighton-hove.gcsx.gov.uk
 
 
@@ -36,25 +34,23 @@ Wycliffe House
 Water Lane
 Wilmslow
 Cheshire SK9 5AF
-Telephone number: 01625 545745
-e-mail: data@dataprotection.gov.uk
-Website: www.dataprotection.gov.uk
+Telephone number: 0303 123 1113 (local rate) or 01625 545 745 (national rate)
+e-mail:  casework@ico.org.uk
+Website: www.ICO.org.uk
 
 
 We can also answer queries regarding this process: please contact me via the contact details below.
 
-Wendy Kassamani
 Information Compliance Officer
 Brighton & Hove City Council
-Hove Town Hall
-Norton Road
-Hove, BN3 4AH
-Wendy.Kassamani@Brighton-Hove.gov.uk
+Kings House, Grand Avenue,
+Hove, BN3 3LS
+FreedomofInformation@Brighton-Hove.gov.uk
 
 
 Re-use of Public Sector Information and Copyright Statement
 Where information has been supplied, you are advised that the copyright in that material is owned by Brighton & Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.
 
-Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.
+Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.
 

--- a/app/views/response_mailer/email_update.html.erb
+++ b/app/views/response_mailer/email_update.html.erb
@@ -16,17 +16,16 @@
 
 <p>In both cases, write to:</p>
 
-<p><b>Wendy Kassamani</b><br>
-Information Compliance Officer<br>
+<p><b>Information Compliance Officer</b>
 Brighton & Hove City Council<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove, BN3 4AH<br>
-<a href="mailto:Wendy.Kassamani@Brighton-Hove.gov.uk">Wendy.Kassamani@Brighton-Hove.gov.uk</a></p>
+Kings House<br>
+Grand Avenue<br>
+Hove, BN3 3LS<br>
+<a href="mailto:freedomofinformation@Brighton-Hove.gov.uk">freedomofinformation@Brighton-Hove.gov.uk</a></p>
 
 
 <p><b>Re-use of Public Sector Information and Copyright Statement</b></p>
 <p>Where information has been supplied, you are advised that the copyright in that material is owned by Brighton &amp; Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.</p>
 
-<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.</p>
+<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.</p>

--- a/app/views/response_mailer/email_update.text.erb
+++ b/app/views/response_mailer/email_update.text.erb
@@ -16,18 +16,17 @@ You may also have questions about the Freedom of Information process at Brighton
 
 In both cases, write to:
 
-Wendy Kassamani
 Information Compliance Officer
 Brighton & Hove City Council
-Hove Town Hall
-Norton Road
-Hove, BN3 4AH
-Wendy.Kassamani@Brighton-Hove.gov.uk
+Kings House,
+Grand Avenue,
+Hove, BN3 3LS
+freedomofinformation@Brighton-Hove.gov.uk
 
 
 Re-use of Public Sector Information and Copyright Statement
 Where information has been supplied, you are advised that the copyright in that material is owned by Brighton & Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.
 
-Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.
+Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.
 

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -3,4 +3,33 @@ Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 1
 #Delayed::Worker.max_run_time = 5.minutes
 #Delayed::Worker.read_ahead = 10
-Delayed::Worker.delay_jobs = Rails.env.production?
+Delayed::Worker.delay_jobs = true
+
+# From http://stackoverflow.com/a/6967915
+
+# Optional but recommended for less future surprises.
+# Fail at startup if method does not exist instead of later in a background job
+[[ExceptionNotifier::Notifier, :background_exception_notification]].each do |object, method_name|
+  raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
+end
+
+# Chain delayed job's handle_failed_job method to do exception notification
+Delayed::Worker.class_eval do
+  def handle_failed_job_with_notification(job, error)
+    handle_failed_job_without_notification(job, error)
+    # only actually send mail in production
+    if Rails.Delayedenv.production?
+      # rescue if ExceptionNotifier fails for some reason
+      begin
+        ExceptionNotifier::Notifier.background_exception_notification(error, :data => {:job => job})
+      rescue Exception => e
+        Rails.logger.error "ExceptionNotifier failed: #{e.class.name}: #{e.message}"
+        e.backtrace.each do |f|
+          Rails.logger.error "  #{f}"
+        end
+        Rails.logger.flush
+      end
+    end
+  end
+  alias_method_chain :handle_failed_job, :notification
+end

--- a/extras/alaveteli_api.rb
+++ b/extras/alaveteli_api.rb
@@ -160,6 +160,19 @@ class AlaveteliApi
 
                     # Get existing user, or make a new one.
                     user_url = event["user_url"]
+
+                    # If the user_url is nil, it means that there's no user
+                    # logged in Alaveteli, which in all likelihood means that
+                    # this is actually a request that *we* sent to alaveteli
+                    # but that somehow doesn't have a remote_id yet (maybe
+                    # something bombed out whilst sending it to Alaveteli, and
+                    # Alaveteli got it but we didn't get their response). This
+                    # is a bad situation to be in, and needs investigating by
+                    # someone immediately, hence raising an error.
+                    if user_url.nil?
+                        raise AlaveteliApiError, "Received request from alaveteli feed with no user_url that doesn't match any existing remote_id: #{remote_id}"
+                    end
+
                     requestor = Requestor.find_by_external_url_scheme_insensitive(user_url)
 
                     # oh, it really is new - better make a new requestor then

--- a/lib/tasks/foi.rake
+++ b/lib/tasks/foi.rake
@@ -9,84 +9,12 @@ require "time"
 namespace :foi do
     desc "Fetch the Alaveteli feed"
     task :fetch => :environment do
-        if !MySociety::Config.get("PULL_FROM_ALAVETELI")
+        api = AlaveteliApi
+        if !api.pull_from_alaveteli?
             puts "Not pulling from Alaveteli, because PULL_FROM_ALAVETELI is false"
             next
-        end
-
-        feed_url = MySociety::Config.get("ALAVETELI_FEED_URL")
-        feed_key = MySociety::Config.get("ALAVETELI_API_KEY")
-
-        url = feed_url + "?k=" + CGI::escape(feed_key)
-
-        ActiveRecord::Base.transaction do
-            last_event_id = AlaveteliFeed.last_event_id
-            if !last_event_id.nil?
-                url += '&since_event_id=' + last_event_id.to_s
-            end
-
-            uri = URI.parse(url)
-            http = Net::HTTP.new(uri.host, uri.port)
-            http.use_ssl = true
-
-            http.ca_path = MySociety::Config.get("SSL_CA_PATH", "/etc/ssl/certs/")
-            http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-            request = Net::HTTP::Get.new(uri.request_uri)
-            response = http.request(request)
-            events = ActiveSupport::JSON.decode(response.body)
-            events.reverse_each do |event|
-
-                event_type = event["event_type"]
-                if event_type == "sent"
-
-                    # Check to see if this is one of our own requests
-                    remote_id = event['request_id']
-                    existing_request = Request.find(:first, :conditions => ['remote_id = ?', remote_id])
-                    next if existing_request
-
-                    # Process the event
-
-                    # Get existing user, or make a new one.
-                    user_url = event["user_url"]
-                    requestor = Requestor.find_by_external_url(user_url)
-
-                    # check to see if there's an http or https equivalent
-                    # of the user_url before creating a new requestor
-                    if requestor.nil?
-                      case user_url[0..4]
-                      when "http:"
-                        requestor = Requestor.find_by_external_url("https://#{user_url[7..-1]}")
-                      when "https"
-                        requestor = Requestor.find_by_external_url("http://#{user_url[8..-1]}")
-                      end
-                    end
-
-                    # oh, it really is new - better make a new requestor then
-                    if requestor.nil?
-                        requestor = Requestor.new(
-                            :name => event["user_name"],
-                            :external_url => user_url
-                        )
-                        requestor.save!
-                    end
-
-                    # Create a request
-                    date_received = Time.iso8601(event["created_at"])
-                    request = Request.new(
-                        :medium => "alaveteli",
-                        :state => "new",
-                        :remote_url => event["request_url"],
-                        :remote_email => event["request_email"],
-                        :requestor => requestor,
-                        :title => event["title"],
-                        :body => event["body"],
-                        :date_received => date_received,
-                        :due_date => date_received + 28.days
-                    )
-                    request.save!
-                end
-            end
-            AlaveteliFeed.last_event_id = events[0]["event_id"] if !events.empty?
+        else
+            api.fetch_feed
         end
     end
 end

--- a/test/fixtures/requestors.yml
+++ b/test/fixtures/requestors.yml
@@ -30,3 +30,11 @@ seb:
 no_email:
   name: Test User
   email:
+
+external_user:
+  name: External User
+  email: external@mysociety.org
+  external_url: https://www.whatdotheyknow.com/users/test
+  notes: |
+    phone: 01243 465 798
+    address: The other place, externalsville, EX1 3RN

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'action_view/base'
 require 'mocha/setup'
+require 'webmock/test_unit'
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.

--- a/test/unit/alaveteli_api_test.rb
+++ b/test/unit/alaveteli_api_test.rb
@@ -1,0 +1,183 @@
+# Test the AlaveteliApi class
+
+require 'test_helper'
+
+class AlaveteliAPITestCase < ActiveSupport::TestCase
+
+  test "pull_from_alaveteli? should return false" do
+    assert_equal AlaveteliApi.pull_from_alaveteli?, false
+  end
+
+  test "test_alaveteli_secure should return false" do
+    assert_equal AlaveteliApi.alaveteli_secure?, false
+  end
+
+  test "fetch_feed should call the right api url" do
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => '[]')
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should send last_event_id to alaveteli" do
+    AlaveteliFeed.expects(:last_event_id).returns(1000)
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1000"
+    stub_request(:get, expected_feed_url).to_return(:body => '[]')
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should skip existing requests" do
+    created_in_app = requests(:created_in_app)
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 1,
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => created_in_app.remote_id,
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => nil
+      }
+    ])
+    # We shouldn't create any new records
+    Request.stubs(:new).never
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should raise an error on empty user_urls" do
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 1,
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => 1000000, # High enough not to be in our test DB
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => nil,
+        :user_url => nil
+      }
+    ])
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    assert_raises AlaveteliApi::AlaveteliApiError do
+      AlaveteliApi.fetch_feed
+    end
+  end
+
+  test "fetch_feed should find existing requestors" do
+    external_user = requestors(:external_user)
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 1,
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => 1000000, # High enough not to be in our test DB
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => external_user.name,
+        :user_url => external_user.external_url
+      }
+    ])
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    Requestor.expects(:new).never
+    mock_request = mock()
+    mock_request.expects(:save!)
+    Request.expects(:new).returns(mock_request)
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should create new requestors" do
+    new_user_url = 'http://www.whatdotheyknow.com/users/new_test_user'
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 1,
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => 1000000, # High enough not to be in our test DB
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => 'New Test User',
+        :user_url => new_user_url
+      }
+    ])
+    mock_requestor = mock()
+    mock_requestor.expects(:save!)
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    Requestor.expects(:find_by_external_url_scheme_insensitive).with(new_user_url).returns(nil)
+    Requestor.expects(:new).with(
+        :name => 'New Test User',
+        :external_url => new_user_url
+      ).returns(mock_requestor)
+    mock_request = mock()
+    mock_request.expects(:save!)
+    Request.expects(:new).returns(mock_request)
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should create new requests" do
+    external_user = requestors(:external_user)
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 1,
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => 1000000, # High enough not to be in our test DB
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => external_user.name,
+        :user_url => external_user.external_url
+      }
+    ])
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    mock_request = mock()
+    mock_request.expects(:save!)
+    Request.expects(:new).with(
+        :medium => "alaveteli",
+        :state => "new",
+        :remote_url => "https://www.whatdotheyknow.com/request/test",
+        :remote_email => "request-1-a@whatdotheyknow.com",
+        :requestor => external_user,
+        :title => "test",
+        :body => "Test",
+        :date_received => Time.iso8601("2015-03-11T10:10:00+00:00"),
+        :due_date => Time.iso8601("2015-03-11T10:10:00+00:00") + 28.days
+      ).returns(mock_request)
+    AlaveteliApi.fetch_feed
+  end
+
+  test "fetch_feed should update last_event_id" do
+    external_user = requestors(:external_user)
+    feed_response = ActiveSupport::JSON.encode([
+      {
+        :body => "Test",
+        :created_at => "2015-03-11T10:10:00+00:00",
+        :event_id => 2, # Default is 1
+        :event_type => "sent",
+        :request_email => "request-1-a@whatdotheyknow.com",
+        :request_id => 1000000, # High enough not to be in our test DB
+        :request_url => "https://www.whatdotheyknow.com/request/test",
+        :title => "test",
+        :user_name => external_user.name,
+        :user_url => external_user.external_url
+      }
+    ])
+    expected_feed_url = "#{MySociety::Config.get('ALAVETELI_FEED_URL')}?k=#{MySociety::Config.get('ALAVETELI_API_KEY')}&since_event_id=1"
+    stub_request(:get, expected_feed_url).to_return(:body => feed_response)
+    AlaveteliApi.fetch_feed
+    assert_equal 2, AlaveteliFeed.last_event_id
+  end
+end

--- a/test/unit/requestor_test.rb
+++ b/test/unit/requestor_test.rb
@@ -25,4 +25,12 @@ class RequestorTest < ActiveSupport::TestCase
     requestor.save
     assert_equal(nil, requestor.email)
   end
+
+  test 'find_by_external_url_scheme_insensitive should find with http or https url' do
+    external_user = requestors(:external_user)
+    external_url_http = "http://www.whatdotheyknow.com/users/test"
+    external_url_https = "https://www.whatdotheyknow.com/users/test"
+    assert_equal(Requestor.find_by_external_url_scheme_insensitive(external_url_http), external_user)
+    assert_equal(Requestor.find_by_external_url_scheme_insensitive(external_url_https), external_user)
+  end
 end


### PR DESCRIPTION
This fixes #238 - where requests with an unknown `request_id` and `nil` `user_url`
were assigned to the wrong user in the foi-reg database. This situation
shouldn't have happened in the first place (see #237), but I thought it was
better to fix this issue whilst I was at it for a belt and braces approach.

I've refactored the code out from `lib/tasks/foi.rake` because it was hard to
test there. I've moved most of it into `extras/alaveteli_api.rb`, with a little
bit added to `app/models/Requestor.rb` where it made sense.

This process didn't have any tests before, so I've written some. Comments on
how to improve these would be appreciated though. I've had to introduce a
dependency on `webmock` in order to test calling the API without actually
needing an alaveteli instance, but I've tried to keep to the existing approach
elsewhere, using `test::unit` and `mocha`

Fixes #238