### PR TITLE
Send exception emails when a delayed job errors

### DIFF
--- a/app/views/request_mailer/acknowledgement.text.erb
+++ b/app/views/request_mailer/acknowledgement.text.erb
@@ -10,6 +10,6 @@ Details of your request:
 
 Your request can be viewed online at: <%= Rails.application.routes.url_helpers.request_url(nil, @request, :host => MySociety::Config.get("DOMAIN", "localhost:3000"), :protocol => (MySociety::Config.get("FOI_REG_SECURE", false) ? 'https' : 'http')) %>
 
-Wendy Kassamani
+
 Information Compliance Officer
 Tel: 01273 296636

--- a/app/views/response_mailer/email_response.html.erb
+++ b/app/views/response_mailer/email_response.html.erb
@@ -18,15 +18,15 @@
 
 <p>Should you have any further queries about this request, please contact me via the details at the foot of this email, quoting the reference number given above.</p>
 
-<p>If you are not satisfied with the handling of your request, you can appeal. Write to:</p>
+<p>If you are not satisfied with the handling of your request, you can appeal (Internal Review) within 2 months of the completed FOI. Write to:</p>
 
 <p>Freedom of Information Appeals<br>
 Brighton & Hove City Council<br>
-ICT Room lst Floor<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove BN3 4AH<br>
-jan.mccartney@brighton-hove.gcsx.gov.uk</p>
+ICT 4th Floor<br>
+Kings House<br>
+Grand Avenue<br>
+Hove BN3 3LS<br>
+information.governance@brighton-hove.gov.uk</p>
 
 <p>If you are still not satisfied after your complaint has been investigated, you can escalate your complaint to the Information Commissioners Office. The contact details are:</p>
 
@@ -35,24 +35,23 @@ Wycliffe House<br>
 Water Lane<br>
 Wilmslow<br>
 Cheshire SK9 5AF<br>
-Telephone number: 01625 545745<br>
-e-mail: <a href="mailto:data@dataprotection.gov.uk">data@dataprotection.gov.uk</a><br>
-Website: <a href="www.dataprotection.gov.uk">www.dataprotection.gov.uk</a></p>
+Helpline: 0303 123 1113 (local rate) or 01625 545 745 (national rate)<br>
+e-mail: <a href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
+Website: <a href="www.ICO.org.uk">www.ICO.org.uk</a></p>
 
 
 <p>We can also answer queries regarding this process: please contact me via the contact details below.</p>
 
-<p><b>Wendy Kassamani</b><br>
-Information Compliance Officer<br>
+<p><b>Information Compliance Officer</b><br>
 Brighton & Hove City Council<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove, BN3 4AH<br>
-<a href="mailto:Wendy.Kassamani@Brighton-Hove.gov.uk">Wendy.Kassamani@Brighton-Hove.gov.uk</a></p>
+Kings House<br>
+Grand Avenue<br>
+Hove, BN3 3LS<br>
+<a href="mailto:freedomofinformation@Brighton-Hove.gov.uk">freedomofinformation@Brighton-Hove.gov.uk</a></p>
 
 
 <p><b>Re-use of Public Sector Information and Copyright Statement</b></p>
 <p>Where information has been supplied, you are advised that the copyright in that material is owned by Brighton &amp; Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.</p>
 
-<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.</p>
+<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.</p>

--- a/app/views/response_mailer/email_response.text.erb
+++ b/app/views/response_mailer/email_response.text.erb
@@ -22,10 +22,8 @@ If you are not satisfied with the handling of your request, you can appeal. Writ
 
 Freedom of Information Appeals
 Brighton & Hove City Council
-ICT Room lst Floor
-Hove Town Hall
-Norton Road
-Hove BN3 4AH
+ICT 4th Floor Kings House Grand Avenue
+Hove BN3 3LS
 jan.mccartney@brighton-hove.gcsx.gov.uk
 
 
@@ -36,25 +34,23 @@ Wycliffe House
 Water Lane
 Wilmslow
 Cheshire SK9 5AF
-Telephone number: 01625 545745
-e-mail: data@dataprotection.gov.uk
-Website: www.dataprotection.gov.uk
+Telephone number: 0303 123 1113 (local rate) or 01625 545 745 (national rate)
+e-mail:  casework@ico.org.uk
+Website: www.ICO.org.uk
 
 
 We can also answer queries regarding this process: please contact me via the contact details below.
 
-Wendy Kassamani
 Information Compliance Officer
 Brighton & Hove City Council
-Hove Town Hall
-Norton Road
-Hove, BN3 4AH
-Wendy.Kassamani@Brighton-Hove.gov.uk
+Kings House, Grand Avenue,
+Hove, BN3 3LS
+FreedomofInformation@Brighton-Hove.gov.uk
 
 
 Re-use of Public Sector Information and Copyright Statement
 Where information has been supplied, you are advised that the copyright in that material is owned by Brighton & Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.
 
-Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.
+Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.
 

--- a/app/views/response_mailer/email_update.html.erb
+++ b/app/views/response_mailer/email_update.html.erb
@@ -16,17 +16,16 @@
 
 <p>In both cases, write to:</p>
 
-<p><b>Wendy Kassamani</b><br>
-Information Compliance Officer<br>
+<p><b>Information Compliance Officer</b>
 Brighton & Hove City Council<br>
-Hove Town Hall<br>
-Norton Road<br>
-Hove, BN3 4AH<br>
-<a href="mailto:Wendy.Kassamani@Brighton-Hove.gov.uk">Wendy.Kassamani@Brighton-Hove.gov.uk</a></p>
+Kings House<br>
+Grand Avenue<br>
+Hove, BN3 3LS<br>
+<a href="mailto:freedomofinformation@Brighton-Hove.gov.uk">freedomofinformation@Brighton-Hove.gov.uk</a></p>
 
 
 <p><b>Re-use of Public Sector Information and Copyright Statement</b></p>
 <p>Where information has been supplied, you are advised that the copyright in that material is owned by Brighton &amp; Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.</p>
 
-<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.</p>
+<p>Authorisation to re-use copyright material not owned by Brighton &amp; Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.</p>

--- a/app/views/response_mailer/email_update.text.erb
+++ b/app/views/response_mailer/email_update.text.erb
@@ -16,18 +16,17 @@ You may also have questions about the Freedom of Information process at Brighton
 
 In both cases, write to:
 
-Wendy Kassamani
 Information Compliance Officer
 Brighton & Hove City Council
-Hove Town Hall
-Norton Road
-Hove, BN3 4AH
-Wendy.Kassamani@Brighton-Hove.gov.uk
+Kings House,
+Grand Avenue,
+Hove, BN3 3LS
+freedomofinformation@Brighton-Hove.gov.uk
 
 
 Re-use of Public Sector Information and Copyright Statement
 Where information has been supplied, you are advised that the copyright in that material is owned by Brighton & Hove City Council and/or its contractor(s) unless otherwise stated.  The supply of documents under the Freedom of Information Act does not give the recipient an automatic right to re-use those documents in a way that would infringe copyright, for example, by making multiple copies, publishing and issuing copies to the public.
 Brief extracts of the material can be reproduced under the “fair dealing” provisions of the Copyright Design and Patents Act 1998 (S.29 and S.30) for the purposes of research for non-commercial purposes, private study, criticism, review and news reporting.
 
-Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-Use should be directed to Mr Paul O’Neill at the address above.
+Authorisation to re-use copyright material not owned by Brighton & Hove City Council and/or its contractor(s) should be sought from the copyright holders concerned. If you are considering re-using the information disclosed to you through this request, for any purpose outside of what could be considered for personal use, then you are required under the Public Sector Re-use of Information Regulations 2005 to make an Application for Re-use to the organisation from which you have requested the information.  Applications for Re-use should be directed to the Data Protection Manager at the address above.
 

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -3,4 +3,33 @@ Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_attempts = 1
 #Delayed::Worker.max_run_time = 5.minutes
 #Delayed::Worker.read_ahead = 10
-Delayed::Worker.delay_jobs = Rails.env.production?
+Delayed::Worker.delay_jobs = true
+
+# From http://stackoverflow.com/a/6967915
+
+# Optional but recommended for less future surprises.
+# Fail at startup if method does not exist instead of later in a background job
+[[ExceptionNotifier::Notifier, :background_exception_notification]].each do |object, method_name|
+  raise NoMethodError, "undefined method `#{method_name}' for #{object.inspect}" unless object.respond_to?(method_name, true)
+end
+
+# Chain delayed job's handle_failed_job method to do exception notification
+Delayed::Worker.class_eval do
+  def handle_failed_job_with_notification(job, error)
+    handle_failed_job_without_notification(job, error)
+    # only actually send mail in production
+    if Rails.Delayedenv.production?
+      # rescue if ExceptionNotifier fails for some reason
+      begin
+        ExceptionNotifier::Notifier.background_exception_notification(error, :data => {:job => job})
+      rescue Exception => e
+        Rails.logger.error "ExceptionNotifier failed: #{e.class.name}: #{e.message}"
+        e.backtrace.each do |f|
+          Rails.logger.error "  #{f}"
+        end
+        Rails.logger.flush
+      end
+    end
+  end
+  alias_method_chain :handle_failed_job, :notification
+end


### PR DESCRIPTION
Uses a snippet I found in the delayed_job config to patch delayed_job's error
handling and notify us using ExceptionNotifier.

I'd still like to monitor delayed_job more closely with a health check page,
but this is a quick win which it would be nice to have too.

Closes #143