### PR TITLE
Increase the read_timeout when calling the Alaveteli api

### DIFF
--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,6 +1,6 @@
 Delayed::Worker.destroy_failed_jobs = false
 #Delayed::Worker.sleep_delay = 60
-#Delayed::Worker.max_attempts = 25
+Delayed::Worker.max_attempts = 1
 #Delayed::Worker.max_run_time = 5.minutes
 #Delayed::Worker.read_ahead = 10
 Delayed::Worker.delay_jobs = Rails.env.production?

--- a/extras/alaveteli_api.rb
+++ b/extras/alaveteli_api.rb
@@ -10,6 +10,8 @@ class AlaveteliApi
 
     def self.prepare_connection(url)
       http = Net::HTTP.new(url.host, url.port)
+      # Increase the timeout because alaveteli is slow sometimes
+      http.read_timeout = 300
       if self.alaveteli_secure?
         http.use_ssl = true
         http.ca_path = MySociety::Config.get("SSL_CA_PATH", "/etc/ssl/certs/")

--- a/test/functional/responses_controller_test.rb
+++ b/test/functional/responses_controller_test.rb
@@ -113,7 +113,7 @@ class ResponsesControllerTest < ActionController::TestCase
       end
   end
 
-  test "should retry later if Alaveteli is down" do
+  test "doesn't retry failed jobs" do
     with_alaveteli do |host|
       with_delayed_jobs do
         # Make sure the queue is clear to start with
@@ -134,8 +134,8 @@ class ResponsesControllerTest < ActionController::TestCase
         AlaveteliApi.unstub(:send_request)
         Delayed::Worker::new.work_off 1
 
-        # Check that worked
-        assert_equal 0, Delayed::Job.count
+        # Check that it's not sent
+        assert_equal 1, Delayed::Job.count
       end
     end
   end


### PR DESCRIPTION
Increase the read_timeout in `Net::Http` from the default (60 seconds) to 5
minutes.

This should hopefully stop problems like that described in #237 and #238
arising from really slow requests to Alaveteli. However, I'm aware that it's
treating the symptoms rather than the cause. I'm not sure what else I could do
though. With this and #243 in place, we should at least know what's gone wrong
if this ever happens again. We can then tidy up the DB manually.

The only other option I can see is to somehow auto-fail the `delayed_job`
job if a `Timeout::Error` occurs, so that it never runs again. We'd then have
to manually inspect both the FOI reg and Alaveteli databases to see what's
happened and could either un-fail it, or set the right remote_id on the
request manually.

That would probably be preferable, but it requires a lot more refactoring
so that the code that receives the error is aware it's a delayed job, and can
actually do anything about it (if that's even possible).

Any thoughts on other options would be much appreciated.

Fixes #237