### PR TITLE
Validate Response title and body when created

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,7 +4,9 @@ require File.expand_path('../application', __FILE__)
 # Load the configuration file
 $:.push(File.join(File.dirname(__FILE__), '../commonlib/rblib'))
 load "config.rb"
-if ENV["RAILS_ENV"] == "test" 
+load "validate.rb"
+
+if ENV["RAILS_ENV"] == "test"
     MySociety::Config.set_file(File.join(Rails.root, 'config', 'test'), true)
 else
     MySociety::Config.set_file(File.join(Rails.root, 'config', 'general'), true)

--- a/test/functional/health_checks_controller_test.rb
+++ b/test/functional/health_checks_controller_test.rb
@@ -57,7 +57,7 @@ class HealthChecksControllerTest < ActionController::TestCase
 
     get :index
     assert_response :error
-    assert response.body.include? "The last request from alaveteli was created over 3 days ago"
+    assert response.body.include? "The last request from alaveteli was created over 14 days ago"
   end
 
   test "should not be ok when there are failed jobs" do

--- a/test/unit/alaveteli_api_test.rb
+++ b/test/unit/alaveteli_api_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 
 class AlaveteliAPITestCase < ActiveSupport::TestCase
 
-  test "pull_from_alaveteli? should return false" do
-    assert_equal AlaveteliApi.pull_from_alaveteli?, false
+  test "pull_from_alaveteli? should return true" do
+    assert_equal AlaveteliApi.pull_from_alaveteli?, true
   end
 
   test "test_alaveteli_secure should return false" do

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -117,4 +117,62 @@ class RequestTest < ActiveSupport::TestCase
     request = Request.new(:requestor => requestors(:no_email))
     assert_equal false, request.has_private_email?
   end
+
+  test 'should allow a normal valid request' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => 'A fairly reasonable title',
+      :body => 'A test request with some content and stuff')
+    assert_equal true, request.valid?
+  end
+
+  test 'should validate that the title is not empty' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => '',
+      :body => 'A test request with some content and stuff')
+    assert_equal false, request.valid?
+    assert_equal "can't be blank", request.errors[:title][0]
+    assert_equal 1, request.errors.count
+  end
+
+  test 'should validate that the title has mixed case' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => 'ALL UPPER CASE',
+      :body => 'A test request with some content and stuff')
+    assert_equal false, request.valid?
+    assert_equal 'Please write the summary using a mixture of capital and lower case letters. This makes it easier for others to read.', request.errors[:title][0]
+    assert_equal 1, request.errors.count
+  end
+
+  test 'should validate that the titles say more than FOI Request' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => 'FOI Request',
+      :body => 'A test request with some content and stuff')
+    assert_equal false, request.valid?
+    assert_equal 'Please describe more what the request is about in the subject. There is no need to say it is an FOI request, we add that on anyway.', request.errors[:title][0]
+    assert_equal 1, request.errors.count
+  end
+
+  test 'should validate that the titles are shorter than 200 chars' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => 'Test Request' * 20,
+      :body => 'A test request with some content and stuff')
+    assert_equal false, request.valid?
+    assert_equal 'Please keep the summary short, like in the subject of an email. You can use a phrase, rather than a full sentence.', request.errors[:title][0]
+    assert_equal 1, request.errors.count
+  end
+
+  test 'should validate that the body has mixed case' do
+    request = Request.new(
+      :requestor => requestors(:robin),
+      :title => 'A fairly reasonable title',
+      :body => 'A MESSAGE WRITTEN ALL IN UPPER CASE!')
+    assert_equal false, request.valid?
+    assert_equal 'Please write your message using a mixture of capital and lower case letters. This makes it easier for others to read.', request.errors[:body][0]
+    assert_equal 1, request.errors.count
+  end
 end


### PR DESCRIPTION
Applies the same validation that alaveteli uses, so that we can be sure
requests we send to Alaveteli will be accepted.

Also fixes a couple of un-related tests that were failing.

Fixes #246