### PR TITLE
Ignore old failed requests when seeing if things have been sent to alaveteli

### DIFF
--- a/config/initializers/health_checks.rb
+++ b/config/initializers/health_checks.rb
@@ -28,7 +28,7 @@ Rails.application.config.after_initialize do
                               :failure_message => "There are requests which haven't been sent to Alaveteli in over an hour",
                               :success_message => 'All requests older than an hour have been sent to Alaveteli',
                               :should_exist => false) do
-                                  Request.where("created_at < ? AND medium != 'alaveteli' AND remote_id IS NULL", Time.now - 1.hours).first
+                                  Request.where("created_at > ? AND created_at < ? AND medium != 'alaveteli' AND remote_id IS NULL", Time.new(2015,5,8,0,0,0), Time.now - 1.hours).first
                               end
 
 

--- a/test/functional/health_checks_controller_test.rb
+++ b/test/functional/health_checks_controller_test.rb
@@ -110,4 +110,31 @@ class HealthChecksControllerTest < ActionController::TestCase
     assert_response :error
     assert response.body.include? "There are requests which haven&#x27;t been sent to Alaveteli in over an hour"
   end
+
+  test "should be ok when there are old invalid requests that haven't been sent" do
+    # Create a request to pass the creation test
+    Request.create(
+      :due_date => Time.now + 5.days,
+      :title => 'Created today, from alaveteli',
+      :requestor => requestors(:seb),
+      :body => 'Created today, from alaveteli',
+      :remote_id => 42,
+      :created_at => Time.now,
+      :medium => 'alaveteli'
+    )
+
+    # Create a request from before 08/05/2015 that hasn't been sent
+    Request.create(
+      :due_date => Time.now,
+      :title => 'Created today, from alaveteli',
+      :requestor => requestors(:seb),
+      :body => 'Created today, from alaveteli',
+      :is_published => true,
+      :remote_id => nil,
+      :created_at => Time.new(2015,5,7,0,0,0)
+    )
+
+    get :index
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Fixes #248, putting up for a PR so that we can discuss if this is the best/
only thing we can do or if we consider editing and re-sending the existing
requests so that they pass validation.